### PR TITLE
Untraify TP2 version

### DIFF
--- a/golden_horse/golden_horse.tp2
+++ b/golden_horse/golden_horse.tp2
@@ -1,7 +1,7 @@
 BACKUP ~golden_horse/backup~
 AUTHOR ~oaq@gmx.com~
 
-VERSION @377
+VERSION ~1.6e~
 
 README ~golden_horse/tra/%LANGUAGE%/golden_horse_readme.txt~ ~golden_horse/golden_horse_readme.txt~
 


### PR DESCRIPTION
TP2 version is a useful reference that shouldn't be traified.